### PR TITLE
video: mdss: Fix dual-DSI issue in LiveDisplay

### DIFF
--- a/drivers/video/fbdev/msm/mdss_livedisplay.c
+++ b/drivers/video/fbdev/msm/mdss_livedisplay.c
@@ -148,6 +148,10 @@ int mdss_livedisplay_update(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 	if (mlc == NULL)
 		return -ENODEV;
 
+	if (mdss_dsi_is_hw_config_dual(ctrl_pdata->shared_data))
+		if (mlc->mfd == NULL)
+			return -ENODEV;
+
 	if (!mlc->caps || !mdss_panel_is_power_on_interactive(pinfo->panel_power_state))
 		return 0;
 


### PR DESCRIPTION
 * The second controller won't have it's own framebuffer, so don't
   dereference a NULL pointer.

Change-Id: I0d0c1475882eb65c8d5bc69c9ac3776b5d60339f